### PR TITLE
Cleanup term on exit

### DIFF
--- a/globe-cli/src/main.rs
+++ b/globe-cli/src/main.rs
@@ -73,7 +73,7 @@ fn start_screensaver() {
             match read().unwrap() {
                 Event::Key(event) => match event.code {
                     // pressing any char key exists the program
-                    KeyCode::Char(c) => return,
+                    KeyCode::Char(c) => break,
                     _ => (),
                 },
                 Event::Resize(width, height) => {
@@ -119,6 +119,12 @@ fn start_screensaver() {
             ));
         }
     }
+
+    stdout.execute(cursor::Show);
+    stdout.execute(cursor::EnableBlinking);
+    stdout.execute(crossterm::event::EnableMouseCapture);
+
+    crossterm::terminal::disable_raw_mode().unwrap();
 }
 
 fn start_interactive() {
@@ -151,7 +157,7 @@ fn start_interactive() {
         if poll(Duration::from_millis(100)).unwrap() {
             match read().unwrap() {
                 Event::Key(event) => match event.code {
-                    KeyCode::Char(c) => return,
+                    KeyCode::Char(c) => break,
                     KeyCode::PageUp => cam_zoom += 0.1,
                     KeyCode::PageDown => cam_zoom -= 0.1,
                     KeyCode::Up => {
@@ -244,4 +250,10 @@ fn start_interactive() {
             ));
         }
     }
+
+    stdout.execute(cursor::Show);
+    stdout.execute(cursor::EnableBlinking);
+    stdout.execute(crossterm::event::EnableMouseCapture);
+
+    crossterm::terminal::disable_raw_mode().unwrap();
 }


### PR DESCRIPTION
I believe this is referenced in #2, but this was a first pass at cleaning up the terminal mode after program exit.  I'm just dropping out of the loop and disabling raw mode and reversing the settings from the start.