### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:1 AS build
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+COPY Cargo.toml /globe/
+COPY ./globe /globe/globe
+COPY ./globe-cli /globe/globe-cli
+WORKDIR /globe/
+
+RUN cargo install --target x86_64-unknown-linux-musl --path ./globe-cli --root /globe/bin/
+
+FROM scratch
+
+COPY --from=build /globe/bin/bin/globe /
+ENTRYPOINT [ "/globe" ]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ cd globe-cli
 makepkg -si
 ```
 
+### Docker
+
+You can also use Docker to try out `globe`, no Rust needed. After cloning the repo, just build and run an image from the `Dockerfile` contained at the root of the project:
+```bash
+docker build -t globe .
+docker run -it --rm globe -s
+```
+
 ## Run
 
 To get a full listing of available features and options, show the `--help`


### PR DESCRIPTION
This PR adds a Dockerfile that can be used to make a Docker image of the globe-cli tool. The file uses a multi-stage build to make a final image containing just the globe executable, and nothing else.

This should encourage users who don't have/don't want to install the Rust toolchain to try out the project.

Of course, it also simplifies the web-scale deployment of mission-critical ASCII globes 🌎