### PR TITLE
add AUR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ cargo install globe-cli
 
 Or `git clone` and `cargo run --release` directly from the repository.
 
+### AUR
+
+`globe` can be installed from available [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=globe-cli&outdated=&SB=n&SO=a&PP=50&do_Search=Go) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
+
+```
+yay -S globe-cli
+```
+
+If you prefer, you can clone the [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=globe-cli&outdated=&SB=n&SO=a&PP=50&do_Search=Go) and then compile them with [makepkg](https://wiki.archlinux.org/index.php/Makepkg). For example,
+
+```
+git clone https://aur.archlinux.org/globe-cli.git
+cd globe-cli
+makepkg -si
+```
 
 ## Run
 


### PR DESCRIPTION
Hey,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following packages for the installation of `globe` on Arch Linux and other distributions that support installing packages from [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository):

* [globe-cli](https://aur.archlinux.org/packages/globe-cli/) (builds from source)
* [globe-cli-bin](https://aur.archlinux.org/packages/globe-cli-bin/) (latest binary)
* [globe-cli-git](https://aur.archlinux.org/packages/globe-cli-git/) (VCS/development package)

I also updated README.md about installation from AUR. (1d2bb19)

BR,
orhun.